### PR TITLE
fix(parsing): use csv-parse to handle optionally double-quoted columns

### DIFF
--- a/lib/readers/csv.js
+++ b/lib/readers/csv.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const EventEmitter = require('events');
 const fs = require('fs');
 const readline = require('n-readlines');
+const csvParse = require('csv-parse/lib/sync');
 
 const UID_HEX32_RE = /^[a-f0-9]{32}$/;
 const SOURCE_FXA = 'fxa';
@@ -18,6 +19,11 @@ class CSVReader extends EventEmitter {
     this.fxaInputPath = fxaInputPath;
     this.salesforceInputPath = salesforceInputPath;
     this.separator = separator;
+    this.cvsParseOptions = {
+      trim: true,
+      delimiter: this.separator
+    }
+
     this.previousUidBySource = {};
     this.buckets = { '0': 0, '1': 0, '2': 0, '3': 0,
                      '4': 0, '5': 0, '6': 0, '7': 0,
@@ -158,7 +164,9 @@ class CSVReader extends EventEmitter {
 
   _splitLineBuffer(lineBuffer) {
     if (lineBuffer) {
-      return lineBuffer.toString('utf8').split(this.separator).map(item => item.trim());
+      const parsed = csvParse(lineBuffer.toString('utf8'), this.cvsParseOptions);
+      assert.ok(parsed.length === 1, 'Line parsed as one row.');
+      return parsed[0]
     }
     // zzzzzzzzzzzzzzzzzzzzzzzzzzz is returned as the UID if a line does not exist.
     // Since uids are hex, this should always be considered > a real UID.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "aws-sdk": "^2.234.1",
     "commander": "^2.15.1",
+    "csv-parse": "2.4.0",
     "n-readlines": "^0.2.8"
   },
   "devDependencies": {

--- a/tests/lib/readers/csv.test.js
+++ b/tests/lib/readers/csv.test.js
@@ -61,6 +61,28 @@ test('_splitLineBuffer, splits, trims', () => {
   ]);
 });
 
+
+test('_splitLineBuffer, splits, trims and handles optional double-quoting', () => {
+  const buffer = new Buffer('  uid,  email , " locale "  ,createDate   ');
+  expect(csvReader._splitLineBuffer(buffer)).toEqual([
+    'uid',
+    'email',
+    ' locale ',
+    'createDate'
+  ]);
+});
+
+test('_splitLineBuffer, splits, trims and handles optional double-quoting of empty string', () => {
+  const buffer = new Buffer('  uid,  email , ""  ,createDate   ');
+  expect(csvReader._splitLineBuffer(buffer)).toEqual([
+    'uid',
+    'email',
+    '',
+    'createDate'
+  ]);
+});
+
+
 test('_splitLineBuffer returns ["zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"] if no buffer', () => {
   expect(csvReader._splitLineBuffer()).toEqual([
     'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'


### PR DESCRIPTION
So, in pulling the locale from accounts into the csv, I remembered that the value there is actually the `accept-language` value, which can in practice contain whitespace. So this PR adds the use of a real csv parser, which can accept optionally double-quoted columns. It is also configured to trim leading/trailing WS on unquoted columns, but will not trim quoted columns. But this accept-language value should be further processed by the rules we use in fxa to determine best language.

r? - @shane-tomlinson 